### PR TITLE
Fix logger recursion (NGWPC-8295)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,33 @@ rserv | Percent of lower zone free water not transferable to the lower zone tens
 <sup>*</sup> The area is used for areal averaging outputs, so the units of area are not important as long as they are consistent.
 
 
+## Logger
+
+The Errror Warning and Trapping Systems (EWTS) has been added to this module using a logging schema. All write statements have been converted to `write_log` statements, which saves the ouptut to a log file based on the log level.
+
+When running within the ngen framework, the log file and log level are handled programatically. When running standalone, logging is defaulted to DISABLED. 
+
+**Running Standalone**
+
+In order to generate log messages when running standalone, the `NGEN_EWTS_LOGGING` environment variable must be set to `ENABLED`. This is the only required environment variable . Other optional logger environment variables exist for specifying the log file full pathname and setting the log level. If the user only enables logging, the log level will be set to INFO and the filename will be created based on the user and module names. All logger setup details are written to the console when the module is run. 
+```
+# Case Sensitive
+export NGEN_EWTS_LOGGING=ENABLED
+export NGEN_LOG_FILE_PATH=<full pathname for log file>
+export SACSMA_LOGLEVEL=<DEBUG, INFO, WARNING, SEVERE, FATAL>
+```
+**Log Levels**
+| Level   | Description                                         | Typical Use                                   |
+|---------|-----------------------------------------------------|-----------------------------------------------|
+| DEBUG   | Detailed diagnostic info for development/troubleshooting. | Variable values, function entry/exit. |
+| FATAL   | Critical failure that aborts or makes app unrecoverable. | Crashes, memory errors, invalid state.        |
+| INFO    | General events confirming expected operations.       | Startup/shutdown, configs, task completions.  |
+| SEVERE  | Significant problem; app may continue in degraded state. | Failed services, corrupted configs, data loss.|
+| WARNING | Potential issue that doesn’t stop execution.         | Deprecated APIs, missing files, repeatable errors. |
+
+Default log level is INFO. The log level is hierarchical. Setting it to INFO, will log INFO, WARNING, SEVERE and FATAL
+messages.
+
 ## Getting help
 
 If you have questions, concerns, bug reports, etc, please file an issue in this repository's Issue Tracker.

--- a/src/share/sacLogger.f90
+++ b/src/share/sacLogger.f90
@@ -19,6 +19,12 @@ module sac_log_module
    logical :: opened_once = .false.
    logical :: logger_initialized = .false.   ! Flag to track if the logger has been initialized
 
+   ! To use Logger while running this module stand-alone, set
+   ! the following environment variables, case-sensitive:
+   !     NGEN_EWTS_LOGGING=ENABLED
+   !     NGEN_LOG_FILE_PATH=<full pathname for log file>
+   !     SACSMA_LOGLEVEL=<DEBUG, INFO, WARNING, SEVERE, FATAL> 
+   !
    ! Constants character(len=1), parameter :: DS = "/"
    character(len=16), parameter :: MODULE_NAME = "Sac-SMA"
    character(len=14), parameter :: LOG_DIR_NGENCERF = "/ngencerf/data"
@@ -36,8 +42,7 @@ module sac_log_module
 contains
 
    subroutine initialize_logger()
-      character(len=256) :: log_env, log_msg
-      character(len=8) :: log_str
+      character(len=256) :: log_env, log_str
       integer :: save_log_level
 
       logger_initialized = .true.
@@ -48,7 +53,7 @@ contains
          call flush(6)
         else
          logging_enabled = .false.
-         print *,trim(MODULE_NAME)," Logging ", trim(log_env)
+         print *,trim(MODULE_NAME)," Logging NOT enabled. EV_EWTS_LOGGING=", trim(log_env)
          call flush(6)
          return
       end if
@@ -68,19 +73,15 @@ contains
       else if (log_str == "FATAL" ) then
          log_level = LOG_LEVEL_FATAL
       else
+         log_str = "INFO (" // trim(EV_MODULE_LOGLEVEL) // " = '" // trim(log_str) // "' INVALID Log Level) Defaulted to INFO"
          log_level = LOG_LEVEL_INFO  ! Default level
       end if
-      print *, trim(MODULE_NAME),"Log level set to ", log_str
-      call flush(6)
 
       ! Get the log file path by calling set_log_file_path
       call set_log_file_path()
 
-      save_log_level = log_level
-      log_level = LOG_LEVEL_INFO ! Ensure this INFO message is always logged
-      log_msg = "Log level set to " // log_str
-      call write_log(log_msg, log_level);
-      log_level = save_log_level;
+      print *, trim(MODULE_NAME)," Log level: ", log_str
+      call flush(6)
    end subroutine initialize_logger
 
    function fit_string(str, target_len) result(fixed_str)
@@ -206,7 +207,6 @@ contains
       character(len=512) :: log_file_dir
       character(len=40) :: timestamp
       integer :: save_log_level
-      character(len=1100) :: log_msg
 
       append_entries = .true.
 
@@ -257,18 +257,13 @@ contains
       if (log_file_ready(append_entries)) then
          if (.not. module_log_env_exists) then
             call write_env_var(EV_MODULE_LOGFILEPATH, log_file_path)
-            print *, "Module ", trim(MODULE_NAME), " Log File: ", trim(log_file_path)
+            print *, trim(MODULE_NAME), " Log File: ", trim(log_file_path)
             call flush(6)
-            save_log_level = log_level
-            log_level = LOG_LEVEL_INFO ! Ensure this INFO message is always logged
-            log_msg = "Logging started. Log File Path: " // log_file_path
-            call write_log(log_msg, log_level);
-            log_level = save_log_level;
          end if
       else
          print *, "Unable to open log file. Log entries will be writen to stdout"
          call flush(6)
-        end if
+      end if
    end subroutine set_log_file_path
 
    ! Log file readiness check

--- a/src/share/sacLogger.f90
+++ b/src/share/sacLogger.f90
@@ -51,7 +51,7 @@ contains
          logging_enabled = .true.
          print *,trim(MODULE_NAME)," Logging ", trim(log_env)
          call flush(6)
-        else
+      else 
          logging_enabled = .false.
          print *,trim(MODULE_NAME)," Logging NOT enabled. EV_EWTS_LOGGING=", trim(log_env)
          call flush(6)


### PR DESCRIPTION
While testing Sac-SMA standalone, a run-time error occurred due to a recursive call to write_log. When write_log starts, it call initialize, which calls set_log_file_path which calls write_log. Refactored to use print statements since these really were not necessary in the log file, thereby removing recursion. 

## Additions

- Comments providing instructions on enabling the EWTS logger when running the module stand-alone.

## Removals

- Unnecessary string building code for the removed write_log statements during initialization.

## Changes

- Converted write_log statements while initializing the logger to print statements.

## Testing

1. Ran /test_cases/ex1/run/namelist.bmi.HHWM8

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
