### PR TITLE
Updates to implement reset time for state restoring (NGWPC-9623)

### DIFF
--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -1231,7 +1231,7 @@ contains
          call reset_model_time(this%model, exec_status)
          if (exec_status == 0) then
             bmi_status = BMI_SUCCESS
-            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_INFO)
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
          else
             bmi_status = BMI_FAILURE
             call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -1227,6 +1227,15 @@ contains
             deallocate(this%model%serialization_buffer)
          end if
          bmi_status = BMI_SUCCESS
+      case("reset_time")
+         call reset_model_time(this%model, exec_status)
+         if (exec_status == 0) then
+            bmi_status = BMI_SUCCESS
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_INFO)
+         else
+            bmi_status = BMI_FAILURE
+            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
+         end if
       case default
          bmi_status = BMI_FAILURE
          call write_log(" Failed to set integer value for  " // name // "", LOG_LEVEL_WARNING)

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -292,6 +292,17 @@ contains
   
   end subroutine cleanup
 
+  SUBROUTINE reset_model_time(model, exec_status)
+    type(sac_type), intent(inout) :: model
+    integer(kind=int64), intent(out) :: exec_status
+    exec_status = 1
+    ! reset time variables to the beginning
+    model%runinfo%itime          = 1                    ! initialize the time loop counter at 1
+    model%runinfo%time_dbl       = 0.d0                 ! start model run at t = 0.0
+    model%runinfo%curr_datetime  = model%runinfo%start_datetime !reset to start time.
+    exec_status = 0
+  END SUBROUTINE reset_model_time
+
   SUBROUTINE new_serialization_request (model, exec_status)
     type(sac_type), intent(inout) :: model
     integer(kind=int64) :: nh !counter for HRUs


### PR DESCRIPTION
BMI save state implementation currently includes saving and loading the current time of the BMI. This is needed for properly loading state during checkpointing, but that would cause hindcasting loading of states to continually increase, and some BMIs might start looking for data in indexes out of range from the configuration files. An additional SetValue message of "reset_time" is needed to allow the SAC SMA BMI to reset its current time to 0 as well as update any other values that create a BMI state equivalent to starting at 0.

## Additions

-

## Removals

-

## Changes

- bmi_sac.f90: Added a new case for reset_time in sac_set_int function that calls another subroutine to reset time variables.
- runSac.f90: Added a new function reset_model_time that resets time variables.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
