### PR TITLE
Implement Soil Storage, GIUH channel inflow, NWM_Ponded_Depth as BMI output variables for SAC-SMA (NGWPC-9763, 9888)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -83,6 +83,7 @@ run_util = \
 	nrtype.f90 \
 	sacLogger.f90 \
 	constants.f90 \
+  giuh_utilities.f90 \
 	namelistModule.f90 \
         parametersType.f90 \
         forcingType.f90 \

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -99,7 +99,7 @@ module bmi_sac_module
 
   ! Exchange items
   integer, parameter :: input_item_count = 3
-  integer, parameter :: output_item_count = 13
+  integer, parameter :: output_item_count = 14
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -170,7 +170,8 @@ contains
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
     output_items(12) = 'tci_giuh'  ! total channel inflow from upstream using GIUH (m)
     output_items(13) = 'nwm_ponded_depth'  ! NWM ponded depth (m)
-
+    output_items(14) = 'uzsmc'  ! upper zone storage content change (m)
+    
     names => output_items
     bmi_status = BMI_SUCCESS
   end function sac_output_var_names
@@ -307,7 +308,7 @@ contains
 
     select case(name)
     case('tair', 'precip', 'pet', &                  ! input vars
-         'qs', 'qg', 'tci', 'eta', 'tci_giuh', &                ! output vars
+         'qs', 'qg', 'tci', 'eta', 'tci_giuh', 'uzsmc' &                ! output vars
          'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'nwm_ponded_depth')
        grid = 0
        bmi_status = BMI_SUCCESS
@@ -821,6 +822,9 @@ contains
     case("bfncc")
        size = sizeof(this%model%modelvar%bfncc(1))
        bmi_status = BMI_SUCCESS
+    case("uzsmc")
+       size = sizeof(this%model%modelvar%uzsmc(1))
+       bmi_status = BMI_SUCCESS       
     case("uztwm")
        size = sizeof(this%model%parameters%uztwm(1))
        bmi_status = BMI_SUCCESS
@@ -994,6 +998,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("nwm_ponded_depth")
        dest(1) = this%model%modelvar%nwm_ponded_depth(1)/1000.0 !convert mm to m
+       bmi_status = BMI_SUCCESS
+    case("uzsmc")
+       dest(1) = this%model%modelvar%uzsmc(1)/1000.0 !convert mm to m
        bmi_status = BMI_SUCCESS
     case("eta")
        dest(1) = this%model%modelvar%eta(1)
@@ -1286,6 +1293,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("nwm_ponded_depth")
        this%model%modelvar%nwm_ponded_depth(1) = src(1)
+       bmi_status = BMI_SUCCESS
+    case("uzsmc")
+       this%model%modelvar%uzsmc(1) = src(1)
        bmi_status = BMI_SUCCESS
     case("eta")
        this%model%modelvar%eta(1) = src(1)

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -168,7 +168,7 @@ contains
     output_items(9) = 'bfs'     ! channel baseflow component (mm)
     output_items(10) = 'bfp'    ! channel baseflow component (mm)
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
-    output_items(12) = 'tci_giuh'  ! total channel inflow from upstream corrected with giuh (m)
+    output_items(12) = 'tci_giuh'  ! total channel inflow from upstream using GIUH (m)
     output_items(13) = 'nwm_ponded_depth'  ! NWM ponded depth (m)
 
     names => output_items

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -99,7 +99,7 @@ module bmi_sac_module
 
   ! Exchange items
   integer, parameter :: input_item_count = 3
-  integer, parameter :: output_item_count = 14
+  integer, parameter :: output_item_count = 15
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -170,7 +170,8 @@ contains
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
     output_items(12) = 'tci_giuh'  ! total channel inflow from upstream using GIUH (m)
     output_items(13) = 'nwm_ponded_depth'  ! NWM ponded depth (m)
-    output_items(14) = 'uzsmc'  ! upper zone storage content change (m)
+    output_items(14) = 'uzsmc'  ! upper zone total storage content (m)
+    output_items(15) = 'uzsmc_ch'  ! upper zone storage content change (m)
     
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -308,7 +309,7 @@ contains
 
     select case(name)
     case('tair', 'precip', 'pet', &                  ! input vars
-         'qs', 'qg', 'tci', 'eta', 'tci_giuh', 'uzsmc' &                ! output vars
+         'qs', 'qg', 'tci', 'eta', 'tci_giuh', 'uzsmc', 'uzsmc_ch', &                ! output vars
          'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'nwm_ponded_depth')
        grid = 0
        bmi_status = BMI_SUCCESS
@@ -604,7 +605,7 @@ contains
 
     select case(name)
     case('tair', 'precip', 'pet',  &                ! input vars
-         'qs', 'qg', 'tci', 'eta', 'tci_giuh', 'nwm_ponded_depth', &                ! output vars
+         'qs', 'qg', 'tci', 'eta', 'tci_giuh', 'nwm_ponded_depth', 'uzsmc', 'uzsmc_ch', &                ! output vars
          'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc')
        type = "real"
        bmi_status = BMI_SUCCESS
@@ -753,10 +754,16 @@ contains
        bmi_status = BMI_SUCCESS
     case("side")
        units = "mm"
-       bmi_status = BMI_SUCCESS 
+       bmi_status = BMI_SUCCESS
     case("rserv")
        units = "mm"
-       bmi_status = BMI_SUCCESS 
+       bmi_status = BMI_SUCCESS
+    case("uzsmc")
+       units = "mm"
+       bmi_status = BMI_SUCCESS
+    case("uzsmc_ch")
+       units = "mm"
+       bmi_status = BMI_SUCCESS
     case default
        units = "-"
        bmi_status = BMI_FAILURE
@@ -824,7 +831,10 @@ contains
        bmi_status = BMI_SUCCESS
     case("uzsmc")
        size = sizeof(this%model%modelvar%uzsmc(1))
-       bmi_status = BMI_SUCCESS       
+       bmi_status = BMI_SUCCESS
+    case("uzsmc_ch")
+       size = sizeof(this%model%modelvar%uzsmc_ch(1))
+       bmi_status = BMI_SUCCESS
     case("uztwm")
        size = sizeof(this%model%parameters%uztwm(1))
        bmi_status = BMI_SUCCESS
@@ -1001,6 +1011,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("uzsmc")
        dest(1) = this%model%modelvar%uzsmc(1)/1000.0 !convert mm to m
+       bmi_status = BMI_SUCCESS
+    case("uzsmc_ch")
+       dest(1) = this%model%modelvar%uzsmc_ch(1)/1000.0 !convert mm to m
        bmi_status = BMI_SUCCESS
     case("eta")
        dest(1) = this%model%modelvar%eta(1)
@@ -1297,6 +1310,9 @@ contains
     case("uzsmc")
        this%model%modelvar%uzsmc(1) = src(1)
        bmi_status = BMI_SUCCESS
+    case("uzsmc_ch")
+       this%model%modelvar%uzsmc_ch(1) = src(1)
+       bmi_status = BMI_SUCCESS
     case("eta")
        this%model%modelvar%eta(1) = src(1)
        bmi_status = BMI_SUCCESS
@@ -1473,7 +1489,7 @@ contains
 !     call print_info(this%model)
 !   end subroutine print_model_info
 #ifdef NGEN_ACTIVE
-  function register_bmi(this) result(bmi_status) bind(C, name="register_bmi")
+  function register_bmi(this) result(bmi_status) bind(C, name="register_bmi_sac")
    use, intrinsic:: iso_c_binding, only: c_ptr, c_loc, c_int
    use iso_c_bmif_2_0
    implicit none

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -99,7 +99,7 @@ module bmi_sac_module
 
   ! Exchange items
   integer, parameter :: input_item_count = 3
-  integer, parameter :: output_item_count = 11
+  integer, parameter :: output_item_count = 12
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -168,6 +168,7 @@ contains
     output_items(9) = 'bfs'     ! channel baseflow component (mm)
     output_items(10) = 'bfp'    ! channel baseflow component (mm)
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
+    output_items(12) = 'nwm_ponded_depth'  ! NWM GUIH ponded depth (mm)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -305,7 +306,7 @@ contains
 
     select case(name)
     case('tair', 'precip', 'pet', &                  ! input vars
-         'qs', 'qg', 'tci', 'eta',  &                ! output vars
+         'qs', 'qg', 'tci', 'eta', &                ! output vars
          'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc')
        grid = 0
        bmi_status = BMI_SUCCESS
@@ -601,7 +602,7 @@ contains
 
     select case(name)
     case('tair', 'precip', 'pet',  &                ! input vars
-         'qs', 'qg', 'tci', 'eta', &                ! output vars
+         'qs', 'qg', 'tci', 'eta', 'nwm_ponded_depth', &                ! output vars
          'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc')
        type = "real"
        bmi_status = BMI_SUCCESS
@@ -657,6 +658,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("tci")
        units = "m"
+       bmi_status = BMI_SUCCESS
+    case("nwm_ponded_depth")
+       units = "mm"
        bmi_status = BMI_SUCCESS
     case("eta")
        units = "mm"
@@ -783,6 +787,9 @@ contains
     case("tci")
        size = sizeof(this%model%modelvar%tci(1))      ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
+    case("nwm_ponded_depth")
+       size = sizeof(this%model%modelvar%nwm_ponded_depth)      ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS   
     case("eta")
        size = sizeof(this%model%modelvar%eta(1))
        bmi_status = BMI_SUCCESS
@@ -974,6 +981,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("tci")
        dest(1) = this%model%modelvar%tci(1)/1000.0 !convert mm to m
+       bmi_status = BMI_SUCCESS
+    case("nwm_ponded_depth")
+       dest(1) = this%model%modelvar%nwm_ponded_depth
        bmi_status = BMI_SUCCESS
     case("eta")
        dest(1) = this%model%modelvar%eta(1)
@@ -1260,6 +1270,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("tci")
        this%model%modelvar%tci(1) = src(1)
+       bmi_status = BMI_SUCCESS
+    case("nwm_ponded_depth")
+       this%model%modelvar%nwm_ponded_depth = src(1)
        bmi_status = BMI_SUCCESS
     case("eta")
        this%model%modelvar%eta(1) = src(1)

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -99,7 +99,7 @@ module bmi_sac_module
 
   ! Exchange items
   integer, parameter :: input_item_count = 3
-  integer, parameter :: output_item_count = 12
+  integer, parameter :: output_item_count = 13
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -168,7 +168,8 @@ contains
     output_items(9) = 'bfs'     ! channel baseflow component (mm)
     output_items(10) = 'bfp'    ! channel baseflow component (mm)
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
-    output_items(12) = 'nwm_ponded_depth'  ! NWM GUIH ponded depth (mm)
+    output_items(12) = 'tci_giuh'  ! total channel inflow from upstream corrected with giuh (m)
+    output_items(13) = 'nwm_ponded_depth'  ! NWM ponded depth (m)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -306,8 +307,8 @@ contains
 
     select case(name)
     case('tair', 'precip', 'pet', &                  ! input vars
-         'qs', 'qg', 'tci', 'eta', &                ! output vars
-         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc')
+         'qs', 'qg', 'tci', 'eta', 'tci_giuh', &                ! output vars
+         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'nwm_ponded_depth')
        grid = 0
        bmi_status = BMI_SUCCESS
     case('uztwm', 'uzfwm', 'lztwm', 'lzfsm',  'hru_area', &     ! parameters
@@ -602,7 +603,7 @@ contains
 
     select case(name)
     case('tair', 'precip', 'pet',  &                ! input vars
-         'qs', 'qg', 'tci', 'eta', 'nwm_ponded_depth', &                ! output vars
+         'qs', 'qg', 'tci', 'eta', 'tci_giuh', 'nwm_ponded_depth', &                ! output vars
          'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc')
        type = "real"
        bmi_status = BMI_SUCCESS
@@ -659,8 +660,11 @@ contains
     case("tci")
        units = "m"
        bmi_status = BMI_SUCCESS
+    case("tci_giuh")
+       units = "m"
+       bmi_status = BMI_SUCCESS
     case("nwm_ponded_depth")
-       units = "mm"
+       units = "m"
        bmi_status = BMI_SUCCESS
     case("eta")
        units = "mm"
@@ -787,8 +791,11 @@ contains
     case("tci")
        size = sizeof(this%model%modelvar%tci(1))      ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
+    case("tci_giuh")
+       size = sizeof(this%model%modelvar%tci_giuh(1))      ! 'sizeof' in gcc & ifort
+       bmi_status = BMI_SUCCESS
     case("nwm_ponded_depth")
-       size = sizeof(this%model%modelvar%nwm_ponded_depth)      ! 'sizeof' in gcc & ifort
+       size = sizeof(this%model%modelvar%nwm_ponded_depth(1))      ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS   
     case("eta")
        size = sizeof(this%model%modelvar%eta(1))
@@ -982,8 +989,11 @@ contains
     case("tci")
        dest(1) = this%model%modelvar%tci(1)/1000.0 !convert mm to m
        bmi_status = BMI_SUCCESS
+    case("tci_giuh")
+       dest(1) = this%model%modelvar%tci_giuh(1)/1000.0 !convert mm to m
+       bmi_status = BMI_SUCCESS
     case("nwm_ponded_depth")
-       dest(1) = this%model%modelvar%nwm_ponded_depth
+       dest(1) = this%model%modelvar%nwm_ponded_depth(1)/1000.0 !convert mm to m
        bmi_status = BMI_SUCCESS
     case("eta")
        dest(1) = this%model%modelvar%eta(1)
@@ -1271,8 +1281,11 @@ contains
     case("tci")
        this%model%modelvar%tci(1) = src(1)
        bmi_status = BMI_SUCCESS
+    case("tci_giuh")
+       this%model%modelvar%tci_giuh(1) = src(1)
+       bmi_status = BMI_SUCCESS
     case("nwm_ponded_depth")
-       this%model%modelvar%nwm_ponded_depth = src(1)
+       this%model%modelvar%nwm_ponded_depth(1) = src(1)
        bmi_status = BMI_SUCCESS
     case("eta")
        this%model%modelvar%eta(1) = src(1)

--- a/src/share/derivedType.f90
+++ b/src/share/derivedType.f90
@@ -11,7 +11,7 @@ module derivedType
     real                               :: roimp_comb, sdro_comb, ssur_comb    
     real                               :: sif_comb, bfs_comb, bfp_comb        
     real                               :: precip_comb, tair_comb, pet_comb
-    real                               :: bfncc_comb    
+    real                               :: bfncc_comb, tci_giuh_comb, nwm_ponded_depth_comb
     !variables for the mass balance check
     real, dimension(:), allocatable    :: precip_sum, eta_sum,tci_sum 
     real, dimension(:), allocatable    :: delta_uztwc_sum, delta_uzfwc_sum     
@@ -64,6 +64,8 @@ module derivedType
     this%tair_comb     = 0.0
     this%pet_comb      = 0.0
     this%bfncc_comb    = 0.0
+    this%tci_giuh_comb = 0.0
+    this%nwm_ponded_depth_comb = 0.0
     this%precip_sum    = 0.0
     this%eta_sum       = 0.0
     this%tci_sum       = 0.0

--- a/src/share/giuh_utilities.f90
+++ b/src/share/giuh_utilities.f90
@@ -1,0 +1,58 @@
+! module for giuh calculations
+module giuhModule
+  use sac_log_module
+  use iso_fortran_env
+
+  implicit none
+   
+contains
+! We need to have a giuh_ordinates array for each HRU. The number of ordinates vary by catchment size.
+! use giuh_ordinates=0.06,0.51,0.28,0.12,0.03
+
+function giuh_convolution_integral(runoff_m, giuh_ordinates, &
+                                   runoff_queue_m_per_timestep) &
+                                   result(runoff_m_now)
+
+  implicit none
+  integer :: sac_log_level = LOG_LEVEL_INFO
+
+  !Function parameters
+  real(kind=8), intent(in)    :: runoff_m
+  real(kind=8), intent(in)    :: giuh_ordinates(:)
+  real(kind=8), intent(inout) :: runoff_queue_m_per_timestep(:)
+
+  real(kind=8) :: runoff_m_now ! Result
+
+  integer :: i, N
+
+  N = size(giuh_ordinates)
+
+  ! Sanity check
+  if (size(runoff_queue_m_per_timestep) < N+1) then
+     error stop "runoff_queue_m_per_timestep must be size N+1"
+     call write_log("Runoff_queue_m_per_timestep must be size N+1", LOG_LEVEL_FATAL)
+  end if
+
+  ! Clear temporary slot (index N+1 in Fortran)
+  runoff_queue_m_per_timestep(N+1) = 0.0d0
+
+  ! Convolution accumulation
+  do i = 1, N
+     runoff_queue_m_per_timestep(i) = runoff_queue_m_per_timestep(i) + &
+                                      giuh_ordinates(i) * runoff_m
+  end do
+
+  ! Current runoff output
+  runoff_m_now = runoff_queue_m_per_timestep(1)
+
+  ! Shift queue left
+  do i = 2, N
+     runoff_queue_m_per_timestep(i-1) = runoff_queue_m_per_timestep(i)
+  end do
+
+  ! Clear last active slot
+  runoff_queue_m_per_timestep(N) = 0.0d0
+
+end function giuh_convolution_integral
+
+end module giuhModule

--- a/src/share/giuh_utilities.f90
+++ b/src/share/giuh_utilities.f90
@@ -9,49 +9,49 @@ contains
 ! We need to have a giuh_ordinates array for each HRU. The number of ordinates vary by catchment size.
 ! use giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 
-function giuh_convolution_integral(runoff_m, giuh_ordinates, &
-                                   runoff_queue_m_per_timestep) &
-                                   result(runoff_m_now)
+function giuh_convolution_integral(runoff_mm, giuh_ordinates, &
+                                   runoff_queue_mm_per_timestep) &
+                                   result(runoff_mm_now)
 
   implicit none
   integer :: sac_log_level = LOG_LEVEL_INFO
 
   !Function parameters
-  real(kind=8), intent(in)    :: runoff_m
+  real, intent(in)    :: runoff_mm
   real(kind=8), intent(in)    :: giuh_ordinates(:)
-  real(kind=8), intent(inout) :: runoff_queue_m_per_timestep(:)
+  real(kind=8), intent(inout) :: runoff_queue_mm_per_timestep(:)
 
-  real(kind=8) :: runoff_m_now ! Result
+  real(kind=8) :: runoff_mm_now ! Result
 
   integer :: i, N
 
   N = size(giuh_ordinates)
 
   ! Sanity check
-  if (size(runoff_queue_m_per_timestep) < N+1) then
-     error stop "runoff_queue_m_per_timestep must be size N+1"
-     call write_log("Runoff_queue_m_per_timestep must be size N+1", LOG_LEVEL_FATAL)
+  if (size(runoff_queue_mm_per_timestep) < N+1) then
+     call write_log("Runoff_queue_mm_per_timestep must be size N+1", LOG_LEVEL_FATAL)
+     error stop "runoff_queue_mm_per_timestep must be size N+1"
   end if
 
   ! Clear temporary slot (index N+1 in Fortran)
-  runoff_queue_m_per_timestep(N+1) = 0.0d0
+  runoff_queue_mm_per_timestep(N+1) = 0.0d0
 
   ! Convolution accumulation
   do i = 1, N
-     runoff_queue_m_per_timestep(i) = runoff_queue_m_per_timestep(i) + &
-                                      giuh_ordinates(i) * runoff_m
+     runoff_queue_mm_per_timestep(i) = runoff_queue_mm_per_timestep(i) + &
+                                      giuh_ordinates(i) * runoff_mm
   end do
 
   ! Current runoff output
-  runoff_m_now = runoff_queue_m_per_timestep(1)
+  runoff_mm_now = runoff_queue_mm_per_timestep(1)
 
   ! Shift queue left
   do i = 2, N
-     runoff_queue_m_per_timestep(i-1) = runoff_queue_m_per_timestep(i)
+     runoff_queue_mm_per_timestep(i-1) = runoff_queue_mm_per_timestep(i)
   end do
 
   ! Clear last active slot
-  runoff_queue_m_per_timestep(N) = 0.0d0
+  runoff_queue_mm_per_timestep(N) = 0.0d0
 
 end function giuh_convolution_integral
 

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -147,16 +147,6 @@ contains
       this%total_area = this%total_area + this%hru_area(nh)
     end do
 
-    ! TODO: Delete the following code block once GIUH ordinates are included in params file. 
-    ! Assign the giuh coordinates. This is a copy of what is in the case statement for giuh_ordinates.
-    !if(LEN(TRIM(this%giuh_info)) > 0) then
-    !  num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
-    !  allocate(this%giuh_ordinates(num_giuh))
-    !  read(this%giuh_info, *) this%giuh_ordinates
-    !  this%num_giuh_ordinates = size(this%giuh_ordinates)
-    !  n_params_read = n_params_read + 1
-    !end if
-    return
   end subroutine read_sac_parameters
 
   ! ==== Open forcings files and read to start of first record

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -32,8 +32,6 @@ contains
     integer                 :: pos
     integer                 :: n_params_read, nh  ! counters
     integer                 :: num_giuh, index ! for GIUH ordinates
-    character(len=50) :: giuh_info = "0.06,0.51,0.28,0.12,0.03" ! temporary until it is included in input parameters file.
-  
     !Use assignment instead of declaration+initialization to avoid SAVE attribute gotcha
     ios = 0
 
@@ -120,12 +118,11 @@ contains
             n_params_read = n_params_read + 1
           case ('giuh_ordinates')
             read(readline, *, iostat=ios) this%giuh_info
-            
             ! Count number of commas to determine size of the ordinates and read them into the array
             num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
             allocate(this%giuh_ordinates(num_giuh))
             read(this%giuh_info, *) this%giuh_ordinates
-            this%num_giuh_ordinates = num_giuh
+            this%num_giuh_ordinates = size(this%giuh_ordinates)
             n_params_read = n_params_read + 1
           case default
             call write_log("parameter " // param // " not recognized in sac parameter file", LOG_LEVEL_WARNING)
@@ -137,7 +134,7 @@ contains
     close(unit=51)
   
     ! quick check on completeness
-    ! TODO: Change this check once the GIUH ordinates are included.
+    ! TODO: Change this check for number of params once the GIUH ordinates are included in params file.
     if(n_params_read /= 18) then
       call write_log('Read ' // itoa(n_params_read) // ' Sac-SMA params, but need 18.  Quitting.', LOG_LEVEL_FATAL)
       stop
@@ -150,11 +147,12 @@ contains
       this%total_area = this%total_area + this%hru_area(nh)
     end do
 
+    ! TODO: Delete the following code block once GIUH ordinates are included in params file. 
     ! Assign the giuh coordinates. This is a copy of what is in the case statement for giuh_ordinates.
     num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
     allocate(this%giuh_ordinates(num_giuh))
     read(this%giuh_info, *) this%giuh_ordinates
-    this%num_giuh_ordinates = num_giuh
+    this%num_giuh_ordinates = size(this%giuh_ordinates)
     n_params_read = n_params_read + 1
 
     return
@@ -333,7 +331,7 @@ contains
       write(*,'("Problem opening file ''", A, "''")') trim(filename)
       stop ":  ERROR EXIT"
     endif
-    write(runinfo%output_fileunits(1),'(A)') 'year mo dy hr tair precip pet qs qg tci eta roimp sdro ssur sif bfs bfp bfncc'   ! header
+    write(runinfo%output_fileunits(1),'(A)') 'year mo dy hr tair precip pet qs qg tci eta roimp sdro ssur sif bfs bfp bfncc tci_giuh nwm_ponded_depth'   ! header
 
     ! if user setting is to write out information for each snowband, open the individual files
     if (namelist%output_hrus == 1) then
@@ -351,7 +349,7 @@ contains
         endif
       
         ! Write 1-line header
-        write(runinfo%output_fileunits(nh+1),'(A)') 'year mo dy hr tair precip pet qs qg tci eta roimp sdro ssur sif bfs bfp bfncc'
+        write(runinfo%output_fileunits(nh+1),'(A)') 'year mo dy hr tair precip pet qs qg tci eta roimp sdro ssur sif bfs bfp bfncc tci_giuh nwm_ponded_depth'
         
       end do  ! end loop over sub-units
       
@@ -536,7 +534,8 @@ contains
             modelvar%qs(n_curr_hru), modelvar%qg(n_curr_hru), modelvar%tci(n_curr_hru), & 
             modelvar%eta(n_curr_hru), modelvar%roimp(n_curr_hru), modelvar%sdro(n_curr_hru), &
             modelvar%ssur(n_curr_hru), modelvar%sif(n_curr_hru), modelvar%bfs(n_curr_hru), &
-            modelvar%bfp(n_curr_hru), modelvar%bfncc(n_curr_hru)
+            modelvar%bfp(n_curr_hru), modelvar%bfncc(n_curr_hru), modelvar%tci_giuh(n_curr_hru), &
+            modelvar%nwm_ponded_depth(n_curr_hru)
       if(ierr /= 0) then
         call write_log("ERROR writing output information for basin average. STOPPING.", LOG_LEVEL_FATAL)
         stop
@@ -560,6 +559,8 @@ contains
     derived%bfs_comb       = 0.0
     derived%bfp_comb       = 0.0
     derived%bfncc_comb     = 0.0
+    derived%tci_giuh_comb  = 0.0
+    derived%nwm_ponded_depth_comb = 0.0
         
     if (n_curr_hru .eq. runinfo%n_hrus) then 
       do nh=1, runinfo%n_hrus
@@ -577,6 +578,8 @@ contains
         derived%bfs_comb         = derived%bfs_comb + modelvar%bfs(nh) * parameters%hru_area(nh)
         derived%bfp_comb         = derived%bfp_comb + modelvar%bfp(nh) * parameters%hru_area(nh)
         derived%bfncc_comb       = derived%bfncc_comb + modelvar%bfncc(nh) * parameters%hru_area(nh)
+        derived%tci_giuh_comb         = derived%tci_giuh_comb + modelvar%tci_giuh(nh) * parameters%hru_area(nh)
+        derived%nwm_ponded_depth_comb = derived%nwm_ponded_depth_comb + modelvar%nwm_ponded_depth(nh) * parameters%hru_area(nh)
       end do
 
       ! take average of weighted sum of HRU areas
@@ -594,13 +597,15 @@ contains
       derived%bfs_comb         = derived%bfs_comb / parameters%total_area
       derived%bfp_comb         = derived%bfp_comb / parameters%total_area
       derived%bfncc_comb       = derived%bfncc_comb / parameters%total_area
+      derived%tci_giuh_comb         = derived%tci_giuh_comb / parameters%total_area
+      derived%nwm_ponded_depth_comb = derived%nwm_ponded_depth_comb / parameters%total_area
 
       ! -- write out combined file that is similar to each area file, but add flow variable in CFS units
       write(runinfo%output_fileunits(1), 32, iostat=ierr) runinfo%curr_yr, runinfo%curr_mo, runinfo%curr_dy, runinfo%curr_hr, &
             derived%tair_comb, derived%precip_comb, derived%pet_comb, &
             derived%qs_comb, derived%qg_comb, derived%tci_comb,derived%eta_comb, &
             derived%roimp_comb, derived%sdro_comb, derived%ssur_comb, &
-            derived%sif_comb, derived%bfs_comb, derived%bfp_comb, derived%bfncc_comb
+            derived%sif_comb, derived%bfs_comb, derived%bfp_comb, derived%bfncc_comb, derived%tci_giuh_comb, derived%nwm_ponded_depth_comb
       if(ierr /= 0) then
         call write_log('Error writing output information for sub-unit ' // itoa(n_curr_hru) // '. STOPPING.', LOG_LEVEL_FATAL)      
         stop

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -149,12 +149,13 @@ contains
 
     ! TODO: Delete the following code block once GIUH ordinates are included in params file. 
     ! Assign the giuh coordinates. This is a copy of what is in the case statement for giuh_ordinates.
-    num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
-    allocate(this%giuh_ordinates(num_giuh))
-    read(this%giuh_info, *) this%giuh_ordinates
-    this%num_giuh_ordinates = size(this%giuh_ordinates)
-    n_params_read = n_params_read + 1
-
+    if(LEN(TRIM(this%giuh_info)) > 0) then
+      num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
+      allocate(this%giuh_ordinates(num_giuh))
+      read(this%giuh_info, *) this%giuh_ordinates
+      this%num_giuh_ordinates = size(this%giuh_ordinates)
+      n_params_read = n_params_read + 1
+    end if
     return
   end subroutine read_sac_parameters
 

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -31,6 +31,8 @@ contains
     integer    	            :: ios   ! specify i4b with nrtype?
     integer                 :: pos
     integer                 :: n_params_read, nh  ! counters
+    integer                 :: num_giuh, index ! for GIUH ordinates
+    character(len=50) :: giuh_info = "0.06,0.51,0.28,0.12,0.03" ! temporary until it is included in input parameters file.
   
     !Use assignment instead of declaration+initialization to avoid SAVE attribute gotcha
     ios = 0
@@ -116,6 +118,15 @@ contains
           case ('rserv')
             read(readline, *, iostat=ios) this%rserv
             n_params_read = n_params_read + 1
+          case ('giuh_ordinates')
+            read(readline, *, iostat=ios) this%giuh_info
+            
+            ! Count number of commas to determine size of the ordinates and read them into the array
+            num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
+            allocate(this%giuh_ordinates(num_giuh))
+            read(this%giuh_info, *) this%giuh_ordinates
+            this%num_giuh_ordinates = num_giuh
+            n_params_read = n_params_read + 1
           case default
             call write_log("parameter " // param // " not recognized in sac parameter file", LOG_LEVEL_WARNING)
         end select
@@ -126,6 +137,7 @@ contains
     close(unit=51)
   
     ! quick check on completeness
+    ! TODO: Change this check once the GIUH ordinates are included.
     if(n_params_read /= 18) then
       call write_log('Read ' // itoa(n_params_read) // ' Sac-SMA params, but need 18.  Quitting.', LOG_LEVEL_FATAL)
       stop
@@ -137,7 +149,14 @@ contains
     do nh=1, runinfo%n_hrus
       this%total_area = this%total_area + this%hru_area(nh)
     end do
-    
+
+    ! Assign the giuh coordinates. This is a copy of what is in the case statement for giuh_ordinates.
+    num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
+    allocate(this%giuh_ordinates(num_giuh))
+    read(this%giuh_info, *) this%giuh_ordinates
+    this%num_giuh_ordinates = num_giuh
+    n_params_read = n_params_read + 1
+
     return
   end subroutine read_sac_parameters
 

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -47,6 +47,7 @@ contains
     ! --- now loop through parameter file and assign parameters 
     n_params_read = 0
     ios = 0
+    num_giuh = 0
     do while(ios .eq. 0)
       read(unit=51,FMT='(A)',IOSTAT=ios) readline
   
@@ -127,16 +128,25 @@ contains
           case default
             call write_log("parameter " // param // " not recognized in sac parameter file", LOG_LEVEL_WARNING)
         end select
-  
       end if
   
     end do
     close(unit=51)
-  
+
+    if (num_giuh .EQ. 0) then
+      !This indicates that giuh ordinates ere not provided. Use the default GIUH ordinates.
+      num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
+      allocate(this%giuh_ordinates(num_giuh))
+      read(this%giuh_info, *) this%giuh_ordinates
+      this%num_giuh_ordinates = size(this%giuh_ordinates)
+      n_params_read = n_params_read + 1
+      call write_log("No GIUH ordinates provided in sac parameter file. Using default ordinates: [0.06,0.51,0.28,0.12,0.03]", LOG_LEVEL_WARNING)
+    end if
+
     ! quick check on completeness
     ! TODO: Change this check for number of params once the GIUH ordinates are included in params file.
-    if(n_params_read /= 18) then
-      call write_log('Read ' // itoa(n_params_read) // ' Sac-SMA params, but need 18.  Quitting.', LOG_LEVEL_FATAL)
+    if(n_params_read /= 19) then
+      call write_log('Read ' // itoa(n_params_read) // ' Sac-SMA params, but need 19.  Quitting.', LOG_LEVEL_FATAL)
       stop
     end if
     
@@ -149,13 +159,13 @@ contains
 
     ! TODO: Delete the following code block once GIUH ordinates are included in params file. 
     ! Assign the giuh coordinates. This is a copy of what is in the case statement for giuh_ordinates.
-    if(LEN(TRIM(this%giuh_info)) > 0) then
-      num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
-      allocate(this%giuh_ordinates(num_giuh))
-      read(this%giuh_info, *) this%giuh_ordinates
-      this%num_giuh_ordinates = size(this%giuh_ordinates)
-      n_params_read = n_params_read + 1
-    end if
+    !if(LEN(TRIM(this%giuh_info)) > 0) then
+    !  num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
+    !  allocate(this%giuh_ordinates(num_giuh))
+    !  read(this%giuh_info, *) this%giuh_ordinates
+    !  this%num_giuh_ordinates = size(this%giuh_ordinates)
+    !  n_params_read = n_params_read + 1
+    !end if
     return
   end subroutine read_sac_parameters
 

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -133,16 +133,6 @@ contains
     end do
     close(unit=51)
 
-    if (num_giuh .EQ. 0) then
-      !This indicates that giuh ordinates ere not provided. Use the default GIUH ordinates.
-      num_giuh = count([(this%giuh_info(index:index)==',', index=1,len_trim(this%giuh_info))]) + 1
-      allocate(this%giuh_ordinates(num_giuh))
-      read(this%giuh_info, *) this%giuh_ordinates
-      this%num_giuh_ordinates = size(this%giuh_ordinates)
-      n_params_read = n_params_read + 1
-      call write_log("No GIUH ordinates provided in sac parameter file. Using default ordinates: [0.06,0.51,0.28,0.12,0.03]", LOG_LEVEL_WARNING)
-    end if
-
     ! quick check on completeness
     ! TODO: Change this check for number of params once the GIUH ordinates are included in params file.
     if(n_params_read /= 19) then

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -28,7 +28,8 @@ module modelVarType
     real, dimension(:), allocatable    :: tci_giuh ! total channel inflow with giuh (mm)
     real(kind=8), allocatable          :: runoff_queue_mm(:, :) ! aggregated runoff with giuh (mm)
     real, dimension(:), allocatable    :: nwm_ponded_depth ! GIUH based NWM Ponded Depth (mm)
-    real, dimension(:), allocatable    :: uzsmc  ! Upper zone storage content change (mm)
+    real, dimension(:), allocatable    :: uzsmc  ! Upper zone soil moisture content (mm)
+    real, dimension(:), allocatable    :: uzsmc_ch  ! Upper zone soil moisture content change (mm)
             
     contains
 
@@ -67,6 +68,7 @@ module modelVarType
     allocate(this%tci_giuh (1:namelist%n_hrus))
     allocate(this%nwm_ponded_depth(1:namelist%n_hrus))
     allocate(this%uzsmc(1:namelist%n_hrus))
+    allocate(this%uzsmc_ch(1:namelist%n_hrus))
 
     ! -- default assignmtents
     this%uztwc(:)          = 0.0
@@ -88,7 +90,8 @@ module modelVarType
     this%bfncc(:)          = 0.0
     this%tci_giuh(:)       = 0.0
     this%nwm_ponded_depth(:)  = 0.0
-    this%uzsmc(:)          = 0.0
+    this%uzsmc(:)          = 0.01
+    this%uzsmc_ch(:)       = 0.0
   end subroutine initModelVar
 
 end module modelVarType

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -90,7 +90,7 @@ module modelVarType
     this%bfncc(:)          = 0.0
     this%tci_giuh(:)       = 0.0
     this%nwm_ponded_depth(:)  = 0.0
-    this%uzsmc(:)          = 0.01
+    this%uzsmc(:)          = 0.0
     this%uzsmc_ch(:)       = 0.0
   end subroutine initModelVar
 

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -25,6 +25,7 @@ module modelVarType
     real, dimension(:), allocatable    :: bfs    ! channel baseflow component (mm)
     real, dimension(:), allocatable    :: bfp    ! channel baseflow component (mm)
     real, dimension(:), allocatable    :: bfncc  ! baseflow non-channelcomponent (mm)
+    real                               :: nwm_ponded_depth ! GIUH based NWM Ponded Depth (mm)
             
     contains
 
@@ -61,23 +62,24 @@ module modelVarType
     allocate(this%bfp   (1:namelist%n_hrus))
     allocate(this%bfncc (1:namelist%n_hrus))   
 ! -- default assignmtents
-    this%uztwc(:)      = 0.0
-    this%uzfwc(:)      = 0.0 
-    this%lztwc(:)      = 0.0 
-    this%lzfsc(:)      = 0.0 
-    this%lzfpc(:)      = 0.0
-    this%adimc(:)      = 0.0
-    this%qs(:)         = 0.0
-    this%qg(:)         = 0.0
-    this%tci(:)        = 0.0
-    this%eta(:)        = 0.0
-    this%roimp(:)      = 0.0
-    this%sdro(:)       = 0.0
-    this%ssur(:)       = 0.0
-    this%sif(:)        = 0.0
-    this%bfs(:)        = 0.0
-    this%bfp(:)        = 0.0
-    this%bfncc(:)      = 0.0
+    this%uztwc(:)          = 0.0
+    this%uzfwc(:)          = 0.0 
+    this%lztwc(:)          = 0.0 
+    this%lzfsc(:)          = 0.0 
+    this%lzfpc(:)          = 0.0
+    this%adimc(:)          = 0.0
+    this%qs(:)             = 0.0
+    this%qg(:)             = 0.0
+    this%tci(:)            = 0.0
+    this%eta(:)            = 0.0
+    this%roimp(:)          = 0.0
+    this%sdro(:)           = 0.0
+    this%ssur(:)           = 0.0
+    this%sif(:)            = 0.0
+    this%bfs(:)            = 0.0
+    this%bfp(:)            = 0.0
+    this%bfncc(:)          = 0.0
+    this%nwm_ponded_depth  = 0.0
   end subroutine initModelVar
 
 end module modelVarType

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -25,7 +25,9 @@ module modelVarType
     real, dimension(:), allocatable    :: bfs    ! channel baseflow component (mm)
     real, dimension(:), allocatable    :: bfp    ! channel baseflow component (mm)
     real, dimension(:), allocatable    :: bfncc  ! baseflow non-channelcomponent (mm)
-    real                               :: nwm_ponded_depth ! GIUH based NWM Ponded Depth (mm)
+    real, dimension(:), allocatable    :: tci_giuh ! total channel inflow corrected with giuh (mm)
+    real(kind=8), allocatable          :: runoff_queue_mm(:, :) ! aggregated runoff with giuh (mm)
+    real, dimension(:), allocatable    :: nwm_ponded_depth ! GIUH based NWM Ponded Depth (mm)
             
     contains
 
@@ -60,8 +62,11 @@ module modelVarType
     allocate(this%sif   (1:namelist%n_hrus))
     allocate(this%bfs   (1:namelist%n_hrus))
     allocate(this%bfp   (1:namelist%n_hrus))
-    allocate(this%bfncc (1:namelist%n_hrus))   
-! -- default assignmtents
+    allocate(this%bfncc (1:namelist%n_hrus))
+    allocate(this%tci_giuh (1:namelist%n_hrus))
+    allocate(this%nwm_ponded_depth(1:namelist%n_hrus))
+
+    ! -- default assignmtents
     this%uztwc(:)          = 0.0
     this%uzfwc(:)          = 0.0 
     this%lztwc(:)          = 0.0 
@@ -79,7 +84,8 @@ module modelVarType
     this%bfs(:)            = 0.0
     this%bfp(:)            = 0.0
     this%bfncc(:)          = 0.0
-    this%nwm_ponded_depth  = 0.0
+    this%tci_giuh(:)       = 0.0
+    this%nwm_ponded_depth(:)  = 0.0
   end subroutine initModelVar
 
 end module modelVarType

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -28,6 +28,7 @@ module modelVarType
     real, dimension(:), allocatable    :: tci_giuh ! total channel inflow with giuh (mm)
     real(kind=8), allocatable          :: runoff_queue_mm(:, :) ! aggregated runoff with giuh (mm)
     real, dimension(:), allocatable    :: nwm_ponded_depth ! GIUH based NWM Ponded Depth (mm)
+    real, dimension(:), allocatable    :: uzsmc  ! Upper zone storage content change (mm)
             
     contains
 
@@ -65,6 +66,7 @@ module modelVarType
     allocate(this%bfncc (1:namelist%n_hrus))
     allocate(this%tci_giuh (1:namelist%n_hrus))
     allocate(this%nwm_ponded_depth(1:namelist%n_hrus))
+    allocate(this%uzsmc(1:namelist%n_hrus))
 
     ! -- default assignmtents
     this%uztwc(:)          = 0.0
@@ -86,6 +88,7 @@ module modelVarType
     this%bfncc(:)          = 0.0
     this%tci_giuh(:)       = 0.0
     this%nwm_ponded_depth(:)  = 0.0
+    this%uzsmc(:)          = 0.0
   end subroutine initModelVar
 
 end module modelVarType

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -25,7 +25,7 @@ module modelVarType
     real, dimension(:), allocatable    :: bfs    ! channel baseflow component (mm)
     real, dimension(:), allocatable    :: bfp    ! channel baseflow component (mm)
     real, dimension(:), allocatable    :: bfncc  ! baseflow non-channelcomponent (mm)
-    real, dimension(:), allocatable    :: tci_giuh ! total channel inflow corrected with giuh (mm)
+    real, dimension(:), allocatable    :: tci_giuh ! total channel inflow with giuh (mm)
     real(kind=8), allocatable          :: runoff_queue_mm(:, :) ! aggregated runoff with giuh (mm)
     real, dimension(:), allocatable    :: nwm_ponded_depth ! GIUH based NWM Ponded Depth (mm)
             

--- a/src/share/parametersType.f90
+++ b/src/share/parametersType.f90
@@ -59,7 +59,6 @@ contains
 
     ! assign defaults (if any)
     this%total_area  = huge(1.0)
-    this%giuh_info="0.06,0.51,0.28,0.12,0.03" !delete this once giuh is included in the parameters file.
     this%num_giuh_ordinates = 0
     
   end subroutine initParams

--- a/src/share/parametersType.f90
+++ b/src/share/parametersType.f90
@@ -15,7 +15,7 @@ type, public :: parameters_type
   real, dimension(:), allocatable                :: uztwm, uzfwm, lztwm, lzfsm, lzfpm, adimp
   real, dimension(:), allocatable                :: uzk, lzpk, lzsk, zperc, rexp
   real, dimension(:), allocatable                :: pctim, pfree, riva, side, rserv
-  real, dimension(:), allocatable                :: giuh_ordinates
+  real(kind=8), dimension(:), allocatable        :: giuh_ordinates
   character(len=50)                              :: giuh_info
   integer                                        :: num_giuh_ordinates
   
@@ -56,10 +56,11 @@ contains
     allocate(this%riva(n_hrus))
     allocate(this%side(n_hrus))
     allocate(this%rserv(n_hrus))    
-    allocate(this%giuh_ordinates(n_hrus))
-    
+
     ! assign defaults (if any)
     this%total_area  = huge(1.0)
+    this%giuh_info="0.06,0.51,0.28,0.12,0.03" !delete this once giuh is included in the parameters file.
+    this%num_giuh_ordinates = 0
     
   end subroutine initParams
 

--- a/src/share/parametersType.f90
+++ b/src/share/parametersType.f90
@@ -15,6 +15,10 @@ type, public :: parameters_type
   real, dimension(:), allocatable                :: uztwm, uzfwm, lztwm, lzfsm, lzfpm, adimp
   real, dimension(:), allocatable                :: uzk, lzpk, lzsk, zperc, rexp
   real, dimension(:), allocatable                :: pctim, pfree, riva, side, rserv
+  real, dimension(:), allocatable                :: giuh_ordinates
+  character(len=50)                              :: giuh_info
+  integer                                        :: num_giuh_ordinates
+  
   ! derived vars
   real                                           :: total_area  ! total basin area used in averaging outputs
 
@@ -52,7 +56,7 @@ contains
     allocate(this%riva(n_hrus))
     allocate(this%side(n_hrus))
     allocate(this%rserv(n_hrus))    
-
+    allocate(this%giuh_ordinates(n_hrus))
     
     ! assign defaults (if any)
     this%total_area  = huge(1.0)

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -201,8 +201,15 @@ contains
         !Obtain the NWM ponded depth as the sum of the runoff queue in this timestep
         modelvar%nwm_ponded_depth(nh) = sum(modelvar%runoff_queue_mm(:,nh))
 
+        !Compute total upper zone storage content at the end of this timestep (used in the soil moisture coupler) 
+        modelvar%uzsmc(nh) = modelvar%uztwc(nh) + modelvar%uzfwc(nh)
+        if (modelvar%uzsmc(nh) .EQ. 0) then
+          call write_log("Storage content is zero. Bumping it to 0.01", LOG_LEVEL_WARNING)
+          modelvar%uzsmc(nh) = 0.01
+        end if
+
         !Compute change in storage content at the end of this timestep (used in the soil moisture coupler) 
-        modelvar%uzsmc(nh) = (modelvar%uztwc(nh) - uztwc_0) + (modelvar%uzfwc(nh) - uzfwc_0)
+        modelvar%uzsmc_ch(nh) = (modelvar%uztwc(nh) - uztwc_0) + (modelvar%uzfwc(nh) - uzfwc_0)
 
         !---------------------------------------------------------------------
         ! Mass balance check

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -203,10 +203,6 @@ contains
 
         !Compute total upper zone storage content at the end of this timestep (used in the soil moisture coupler) 
         modelvar%uzsmc(nh) = modelvar%uztwc(nh) + modelvar%uzfwc(nh)
-        if (modelvar%uzsmc(nh) .EQ. 0) then
-          call write_log("Storage content is zero. Bumping it to 0.01", LOG_LEVEL_WARNING)
-          modelvar%uzsmc(nh) = 0.01
-        end if
 
         !Compute change in storage content at the end of this timestep (used in the soil moisture coupler) 
         modelvar%uzsmc_ch(nh) = (modelvar%uztwc(nh) - uztwc_0) + (modelvar%uzfwc(nh) - uzfwc_0)

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -201,6 +201,9 @@ contains
         !Obtain the NWM ponded depth as the sum of the runoff queue in this timestep
         modelvar%nwm_ponded_depth(nh) = sum(modelvar%runoff_queue_mm(:,nh))
 
+        !Compute change in storage content at the end of this timestep (used in the soil moisture coupler) 
+        modelvar%uzsmc(nh) = (modelvar%uztwc(nh) - uztwc_0) + (modelvar%uzfwc(nh) - uzfwc_0)
+
         !---------------------------------------------------------------------
         ! Mass balance check
         !---------------------------------------------------------------------

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -195,7 +195,7 @@ contains
                     modelvar%roimp(nh), modelvar%sdro(nh), modelvar%ssur(nh), &
                     modelvar%sif(nh), modelvar%bfs(nh), modelvar%bfp(nh), modelvar%bfncc(nh) )
 
-        !Obtain the GIUH corrected channel inflow
+        !Obtain the channel inflow using GIUH
         modelvar%tci_giuh(nh) = giuh_convolution_integral(modelvar%tci(nh), parameters%giuh_ordinates, modelvar%runoff_queue_mm(:,nh))
 
         !Obtain the NWM ponded depth as the sum of the runoff queue in this timestep
@@ -323,7 +323,7 @@ contains
         mp_sub_arr%values(4)%obj = mp_float_type(model%modelvar%lzfsc(nh)) !lzfsc
         mp_sub_arr%values(5)%obj = mp_float_type(model%modelvar%lzfpc(nh)) !lzfpc
         mp_sub_arr%values(6)%obj = mp_float_type(model%modelvar%adimc(nh)) !adimc
-        mp_sub_arr%values(7)%obj = mp_float_type(model%modelvar%nwm_ponded_depth(nh)) !nwm_ponded_depth
+        mp_sub_arr%values(7)%obj = transfer_values_to_mp(model%modelvar%runoff_queue_mm(:,nh)) !runoff queue for GIUH
         mp_hru_arr%values(nh)%obj = mp_sub_arr
     end do
 
@@ -360,6 +360,7 @@ contains
     class(mp_arr_type), allocatable :: arr
     class(mp_arr_type), allocatable :: arr_all_hrus
     class(mp_arr_type), allocatable :: arr_state
+    class(mp_arr_type), allocatable :: mp_runoff_queue_arr
     integer(kind=int64) :: nh, yr, mo, dd, hr, itimestep
     real(kind=real64) :: uztwc, uzfwc, lztwc, lzfsc, lzfpc, adimc, itime_dbl, nwm_ponded_depth
     logical :: status
@@ -415,16 +416,18 @@ contains
               model%modelvar%lzfpc(nh) = lzfpc
               call get_real(arr%values(6)%obj, adimc, status) !adimc
               model%modelvar%adimc(nh) = adimc
-              call get_real(arr%values(7)%obj, nwm_ponded_depth, status) !nwm_ponded_depth
-              model%modelvar%nwm_ponded_depth(nh) = nwm_ponded_depth   
+              if (is_arr(arr%values(7)%obj)) then
+                call get_arr_ref(arr%values(7)%obj, mp_runoff_queue_arr, status)
+                model%modelvar%runoff_queue_mm(:,nh) = transfer_values_from_mp(mp_runoff_queue_arr)
+              end if
             else
-              call write_log("Serialization using messagepack (HRU internal array) failed!. Error:" // mp%error_message, LOG_LEVEL_FATAL)
+              call write_log("Deserialization using messagepack (HRU internal array) failed!. Error:" // mp%error_message, LOG_LEVEL_FATAL)
               exec_status = 1
               return
             end if
           end do
         else
-          call write_log("Serialization using messagepack (external HRU array) failed!. Error:" // mp%error_message, LOG_LEVEL_FATAL)
+          call write_log("Deserialization using messagepack (external HRU array) failed!. Error:" // mp%error_message, LOG_LEVEL_FATAL)
           exec_status = 1
           return
         end if
@@ -437,5 +440,42 @@ contains
     exec_status = 0
   
   END SUBROUTINE deserialize_mp_buffer
+
+  FUNCTION transfer_values_to_mp (src) RESULT (dest)
+
+    real(kind=8), dimension(:), intent(in) :: src
+    type(mp_arr_type) :: dest
+    integer :: lb, ub, index, arr_size
+
+    lb = LBOUND(src,1)
+    ub = UBOUND(src,1)
+    arr_size = size(src)
+    dest = mp_arr_type(arr_size)
+    
+    do index = lb, ub
+        dest%values(index)%obj = mp_float_type(src(index))
+    end do
+
+  END FUNCTION transfer_values_to_mp
+
+  FUNCTION transfer_values_from_mp (src) RESULT (dest)
+
+    class(mp_arr_type), intent(in) :: src
+    real(kind=8), allocatable, dimension(:) :: dest
+    real(kind=8) :: deserialized_val
+    integer :: index, lb, ub
+    logical :: status
+    
+    lb = lbound(src%values, 1)
+    ub = ubound(src%values, 1)
+
+    allocate(dest(lb:ub))
+    
+    do index = lb, ub
+        call get_real(src%values(index)%obj, deserialized_val, status)
+        dest(index) = deserialized_val
+    end do
+
+  END FUNCTION transfer_values_from_mp
 
 end module runModule              

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -10,6 +10,7 @@ module runModule
   use modelVarType
   use derivedType
   use sac_log_module
+  use giuhModule
   use messagepack
   use iso_fortran_env
 
@@ -100,18 +101,22 @@ contains
       endif
 #endif
 
+      !---------------------------------------------------------------------
+      ! Lastly, initialize the runoff_queue_mm for the giuh_convolution_integral
+      !---------------------------------------------------------------------
+      allocate(modelvar%runoff_queue_mm(parameters%num_giuh_ordinates + 1, runinfo%n_hrus))
+      modelvar%runoff_queue_mm = 0.0
     end associate ! terminate the associate block
 
   END SUBROUTINE initialize_from_file                
-              
-             
-             
+
   ! == Move the model ahead one time step ================================================================
   SUBROUTINE advance_in_time(model)
     type (sac_type), intent (inout) :: model
     
     ! -- run sac for one time step
     call solve_sac(model)
+    
     ! -- advance run time info
     model%runinfo%itime         = model%runinfo%itime + 1                            ! increment the integer time by 1
     !model%runinfo%time_dbl     = dble(model%runinfo%time_dbl + model%runinfo%dt)    ! increment relative model run time in seconds by DT
@@ -139,7 +144,7 @@ contains
     real               :: adimc_0
     real               :: dt_mass_bal
     character(50)      :: str_real
-
+    
     associate(namelist   => model%namelist,   &
               runinfo    => model%runinfo,    &
               parameters => model%parameters, &
@@ -153,7 +158,7 @@ contains
 #ifndef NGEN_FORCING_ACTIVE
       call read_areal_forcing(namelist, parameters, runinfo, forcing)
 #endif
-
+      
       !---------------------------------------------------------------------
       ! call the main sac state update routine in loop over spatial sub-units
       !---------------------------------------------------------------------
@@ -188,8 +193,14 @@ contains
                     ! Sac Outputs
                     modelvar%qs(nh), modelvar%qg(nh), modelvar%tci(nh), modelvar%eta(nh), &
                     modelvar%roimp(nh), modelvar%sdro(nh), modelvar%ssur(nh), &
-                    modelvar%sif(nh), modelvar%bfs(nh), modelvar%bfp(nh), modelvar%bfncc(nh) )   
-                                                   
+                    modelvar%sif(nh), modelvar%bfs(nh), modelvar%bfp(nh), modelvar%bfncc(nh) )
+
+        !Obtain the GIUH corrected channel inflow
+        modelvar%tci_giuh(nh) = giuh_convolution_integral(modelvar%tci(nh), parameters%giuh_ordinates, modelvar%runoff_queue_mm(:,nh))
+
+        !Obtain the NWM ponded depth as the sum of the runoff queue in this timestep
+        modelvar%nwm_ponded_depth(nh) = sum(modelvar%runoff_queue_mm(:,nh))
+
         !---------------------------------------------------------------------
         ! Mass balance check
         !---------------------------------------------------------------------
@@ -305,13 +316,14 @@ contains
     mp = msgpack()
     mp_hru_arr = mp_arr_type(model%runinfo%n_hrus)
     do nh=1, model%runinfo%n_hrus
-        mp_sub_arr = mp_arr_type(6)
+        mp_sub_arr = mp_arr_type(7)
         mp_sub_arr%values(1)%obj = mp_float_type(model%modelvar%uztwc(nh)) !uztwc
         mp_sub_arr%values(2)%obj = mp_float_type(model%modelvar%uzfwc(nh)) !uzfwc
         mp_sub_arr%values(3)%obj = mp_float_type(model%modelvar%lztwc(nh)) !lztwc
         mp_sub_arr%values(4)%obj = mp_float_type(model%modelvar%lzfsc(nh)) !lzfsc
         mp_sub_arr%values(5)%obj = mp_float_type(model%modelvar%lzfpc(nh)) !lzfpc
         mp_sub_arr%values(6)%obj = mp_float_type(model%modelvar%adimc(nh)) !adimc
+        mp_sub_arr%values(7)%obj = mp_float_type(model%modelvar%nwm_ponded_depth(nh)) !nwm_ponded_depth
         mp_hru_arr%values(nh)%obj = mp_sub_arr
     end do
 
@@ -349,7 +361,7 @@ contains
     class(mp_arr_type), allocatable :: arr_all_hrus
     class(mp_arr_type), allocatable :: arr_state
     integer(kind=int64) :: nh, yr, mo, dd, hr, itimestep
-    real(kind=real64) :: uztwc, uzfwc, lztwc, lzfsc, lzfpc, adimc, itime_dbl
+    real(kind=real64) :: uztwc, uzfwc, lztwc, lzfsc, lzfpc, adimc, itime_dbl, nwm_ponded_depth
     logical :: status
     character (len=10) :: datehr
 
@@ -402,7 +414,9 @@ contains
               call get_real(arr%values(5)%obj, lzfpc, status) !lzfpc
               model%modelvar%lzfpc(nh) = lzfpc
               call get_real(arr%values(6)%obj, adimc, status) !adimc
-              model%modelvar%adimc(nh) = adimc   
+              model%modelvar%adimc(nh) = adimc
+              call get_real(arr%values(7)%obj, nwm_ponded_depth, status) !nwm_ponded_depth
+              model%modelvar%nwm_ponded_depth(nh) = nwm_ponded_depth   
             else
               call write_log("Serialization using messagepack (HRU internal array) failed!. Error:" // mp%error_message, LOG_LEVEL_FATAL)
               exec_status = 1


### PR DESCRIPTION
This PR implements NWM_PONDED_DEPTH as a BMI output variable for SAC-SMA. This involves porting the GIUH Convolution Integral function from C to Fortran and using it to produce an updated channel inflow for upstream.

## Additions

- giuh_utilities.f90: This contains the giuh convolution integral function.

## Removals

-

## Changes

- bmi_sac.f90: Added code to get/set `tci_giuh`, `nwm_ponded_depth`, `uzsmc` and `uzsmc_ch` variables, their size and added them to the output variables array.
- modelVarType.f90: Included  `uzsmc` and `uzsmc_ch`, `tci_giuh` and `nwm_ponded_depth` as model variables and allocate memory in initialization.
- parametersType.f90: Included giuh related variables to read the ordinates. Initialize the number of giuh ordinates to zero.
- ioModule.f90: Included functionality to read the giuh related parameters from parameters file when that specification is included. Currently, it uses a default set of ordinates. Also added the new variables to the output files.
- derivedType.f90: Included variables to sum up the channel inflow of the HRUs together.
- runSac.f90: Added functionality to calculate giuh-corrected channel inflow and also compute the ponded depth. Added functionality to sum up the upper zone soil storage and compute change between timesteps to allow coupling with SMP.

## Testing

1. Tested with a sample realization config with the new output variables and the catchment output contained those variables.
2. Tested coupling with a sample realization config with the storage and storage change being fed into the SMP using variable mapping.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
