### PR TITLE
Update SAC-SMA to output rain+melt

### DIFF
--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -99,7 +99,7 @@ module bmi_sac_module
 
   ! Exchange items
   integer, parameter :: input_item_count = 3
-  integer, parameter :: output_item_count = 11
+  integer, parameter :: output_item_count = 12
   character (len=BMI_MAX_VAR_NAME), target, &
        dimension(input_item_count) :: input_items
   character (len=BMI_MAX_VAR_NAME), target, &
@@ -168,6 +168,7 @@ contains
     output_items(9) = 'bfs'     ! channel baseflow component (mm)
     output_items(10) = 'bfp'    ! channel baseflow component (mm)
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
+    output_items(12) = 'qrain'  ! rain+melt liquid input (mm/s)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -257,6 +258,7 @@ contains
     class (bmi_sac), intent(inout) :: this
     integer :: bmi_status
 
+    this%model%derived%precip_comb = this%model%forcing%precip(1)
     call advance_in_time(this%model)
     bmi_status = BMI_SUCCESS
   end function sac_update
@@ -306,7 +308,7 @@ contains
     select case(name)
     case('tair', 'precip', 'pet', &                  ! input vars
          'qs', 'qg', 'tci', 'eta',  &                ! output vars
-         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc')
+         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'qrain')
        grid = 0
        bmi_status = BMI_SUCCESS
     case('uztwm', 'uzfwm', 'lztwm', 'lzfsm',  'hru_area', &     ! parameters
@@ -748,6 +750,9 @@ contains
     case("rserv")
        units = "mm"
        bmi_status = BMI_SUCCESS 
+    case("qrain")
+       units = "mm/s"
+       bmi_status = BMI_SUCCESS
     case default
        units = "-"
        bmi_status = BMI_FAILURE
@@ -806,6 +811,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("bfncc")
        size = sizeof(this%model%modelvar%bfncc(1))
+       bmi_status = BMI_SUCCESS
+    case("qrain")
+       size = sizeof(this%model%derived%precip_comb)
        bmi_status = BMI_SUCCESS
     case("uztwm")
        size = sizeof(this%model%parameters%uztwm(1))
@@ -998,6 +1006,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("bfncc")
        dest(1) = this%model%modelvar%bfncc(1)
+       bmi_status = BMI_SUCCESS
+    case("qrain")
+       dest(1) = this%model%derived%precip_comb
        bmi_status = BMI_SUCCESS
     case("uztwm")
        dest(1) = this%model%parameters%uztwm(1)
@@ -1284,6 +1295,9 @@ contains
        bmi_status = BMI_SUCCESS
     case("bfncc")
        this%model%modelvar%bfncc(1) = src(1)
+       bmi_status = BMI_SUCCESS
+    case("qrain")
+       this%model%derived%precip_comb = src(1)
        bmi_status = BMI_SUCCESS
     case("uztwm")
        this%model%parameters%uztwm(1) = src(1)

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -168,7 +168,7 @@ contains
     output_items(9) = 'bfs'     ! channel baseflow component (mm)
     output_items(10) = 'bfp'    ! channel baseflow component (mm)
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
-    output_items(12) = 'qrain'  ! rain+melt liquid input (mm/s)
+    output_items(12) = 'rmelt'  ! rain+melt liquid input (mm/s)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -319,7 +319,7 @@ contains
     select case(name)
     case('tair', 'precip', 'pet', &                  ! input vars
          'qs', 'qg', 'tci', 'eta',  &                ! output vars
-         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'qrain')
+         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'rmelt')
        grid = 0
        bmi_status = BMI_SUCCESS
     case('uztwm', 'uzfwm', 'lztwm', 'lzfsm',  'hru_area', &     ! parameters
@@ -615,7 +615,7 @@ contains
     select case(name)
     case('tair', 'precip', 'pet',  &                ! input vars
          'qs', 'qg', 'tci', 'eta', &                ! output vars
-         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'qrain')
+         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'rmelt')
        type = "real"
        bmi_status = BMI_SUCCESS
     case('uztwm', 'uzfwm', 'lztwm', 'lzfsm',  'hru_area', &     ! parameters
@@ -761,7 +761,7 @@ contains
     case("rserv")
        units = "mm"
        bmi_status = BMI_SUCCESS 
-    case("qrain")
+    case("rmelt")
        units = "mm/s"
        bmi_status = BMI_SUCCESS
     case default
@@ -823,7 +823,7 @@ contains
     case("bfncc")
        size = sizeof(this%model%modelvar%bfncc(1))
        bmi_status = BMI_SUCCESS
-    case("qrain")
+    case("rmelt")
        size = sizeof(this%model%derived%precip_comb)
        bmi_status = BMI_SUCCESS
     case("uztwm")
@@ -1018,7 +1018,7 @@ contains
     case("bfncc")
        dest(1) = this%model%modelvar%bfncc(1)
        bmi_status = BMI_SUCCESS
-    case("qrain")
+    case("rmelt")
        dest(1) = this%model%derived%precip_comb
        bmi_status = BMI_SUCCESS
     case("uztwm")
@@ -1307,7 +1307,7 @@ contains
     case("bfncc")
        this%model%modelvar%bfncc(1) = src(1)
        bmi_status = BMI_SUCCESS
-    case("qrain")
+    case("rmelt")
        this%model%derived%precip_comb = src(1)
        bmi_status = BMI_SUCCESS
     case("uztwm")

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -257,8 +257,19 @@ contains
   function sac_update(this) result (bmi_status)
     class (bmi_sac), intent(inout) :: this
     integer :: bmi_status
+    real :: p
 
-    this%model%derived%precip_comb = this%model%forcing%precip(1)
+    p = this%model%forcing%precip(1)
+
+    ! enforce non-negative and handle uninitialized junk
+    if (p /= p) then                      ! NaN check (NaN != NaN)
+       p = 0.0
+    else if (p < 0.0) then
+       p = 0.0
+    end if
+
+    this%model%derived%precip_comb = p
+
     call advance_in_time(this%model)
     bmi_status = BMI_SUCCESS
   end function sac_update
@@ -604,7 +615,7 @@ contains
     select case(name)
     case('tair', 'precip', 'pet',  &                ! input vars
          'qs', 'qg', 'tci', 'eta', &                ! output vars
-         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc')
+         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'qrain')
        type = "real"
        bmi_status = BMI_SUCCESS
     case('uztwm', 'uzfwm', 'lztwm', 'lzfsm',  'hru_area', &     ! parameters

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -168,7 +168,7 @@ contains
     output_items(9) = 'bfs'     ! channel baseflow component (mm)
     output_items(10) = 'bfp'    ! channel baseflow component (mm)
     output_items(11) = 'bfncc'  ! non-channel baseflow component (mm)
-    output_items(12) = 'rmelt'  ! rain+melt liquid input (mm/s)
+    output_items(12) = 'precip_out'  ! rain+melt liquid input (mm/s)
 
     names => output_items
     bmi_status = BMI_SUCCESS
@@ -306,7 +306,7 @@ contains
     select case(name)
     case('tair', 'precip', 'pet', &                  ! input vars
          'qs', 'qg', 'tci', 'eta',  &                ! output vars
-         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'rmelt')
+         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'precip_out')
        grid = 0
        bmi_status = BMI_SUCCESS
     case('uztwm', 'uzfwm', 'lztwm', 'lzfsm',  'hru_area', &     ! parameters
@@ -602,7 +602,7 @@ contains
     select case(name)
     case('tair', 'precip', 'pet',  &                ! input vars
          'qs', 'qg', 'tci', 'eta', &                ! output vars
-         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'rmelt')
+         'roimp','sdro','ssur','sif','bfs','bfp', 'bfncc', 'precip_out')
        type = "real"
        bmi_status = BMI_SUCCESS
     case('uztwm', 'uzfwm', 'lztwm', 'lzfsm',  'hru_area', &     ! parameters
@@ -640,7 +640,7 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case("precip", "rmelt")
+    case("precip", "precip_out")
        units = "mm/s"
        bmi_status = BMI_SUCCESS
     case("tair")
@@ -763,7 +763,7 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case("precip", "rmelt")
+    case("precip", "precip_out")
        size = sizeof(this%model%forcing%precip(1))
 !       size = sizeof(this%model%derived%precip_comb)    ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
@@ -955,7 +955,7 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case("precip", "rmelt")
+    case("precip", "precip_out")
        dest(1) = this%model%forcing%precip(1)
 !       dest(1) = this%model%derived%precip_comb
        bmi_status = BMI_SUCCESS

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -257,19 +257,6 @@ contains
   function sac_update(this) result (bmi_status)
     class (bmi_sac), intent(inout) :: this
     integer :: bmi_status
-    real :: p
-
-    p = this%model%forcing%precip(1)
-
-    ! enforce non-negative and handle uninitialized junk
-    if (p /= p) then                      ! NaN check (NaN != NaN)
-       p = 0.0
-    else if (p < 0.0) then
-       p = 0.0
-    end if
-
-    this%model%derived%precip_comb = p
-
     call advance_in_time(this%model)
     bmi_status = BMI_SUCCESS
   end function sac_update
@@ -653,7 +640,7 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case("precip")
+    case("precip", "rmelt")
        units = "mm/s"
        bmi_status = BMI_SUCCESS
     case("tair")
@@ -761,9 +748,6 @@ contains
     case("rserv")
        units = "mm"
        bmi_status = BMI_SUCCESS 
-    case("rmelt")
-       units = "mm/s"
-       bmi_status = BMI_SUCCESS
     case default
        units = "-"
        bmi_status = BMI_FAILURE
@@ -779,7 +763,7 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case("precip")
+    case("precip", "rmelt")
        size = sizeof(this%model%forcing%precip(1))
 !       size = sizeof(this%model%derived%precip_comb)    ! 'sizeof' in gcc & ifort
        bmi_status = BMI_SUCCESS
@@ -822,9 +806,6 @@ contains
        bmi_status = BMI_SUCCESS
     case("bfncc")
        size = sizeof(this%model%modelvar%bfncc(1))
-       bmi_status = BMI_SUCCESS
-    case("rmelt")
-       size = sizeof(this%model%derived%precip_comb)
        bmi_status = BMI_SUCCESS
     case("uztwm")
        size = sizeof(this%model%parameters%uztwm(1))
@@ -974,9 +955,8 @@ contains
     integer :: bmi_status
 
     select case(name)
-    case("precip")
+    case("precip", "rmelt")
        dest(1) = this%model%forcing%precip(1)
-!       dest(1) = this%model%derived%precip_comb
        bmi_status = BMI_SUCCESS
     case("tair")
        dest(1) = this%model%forcing%tair(1)
@@ -1017,9 +997,6 @@ contains
        bmi_status = BMI_SUCCESS
     case("bfncc")
        dest(1) = this%model%modelvar%bfncc(1)
-       bmi_status = BMI_SUCCESS
-    case("rmelt")
-       dest(1) = this%model%derived%precip_comb
        bmi_status = BMI_SUCCESS
     case("uztwm")
        dest(1) = this%model%parameters%uztwm(1)
@@ -1306,9 +1283,6 @@ contains
        bmi_status = BMI_SUCCESS
     case("bfncc")
        this%model%modelvar%bfncc(1) = src(1)
-       bmi_status = BMI_SUCCESS
-    case("rmelt")
-       this%model%derived%precip_comb = src(1)
        bmi_status = BMI_SUCCESS
     case("uztwm")
        this%model%parameters%uztwm(1) = src(1)

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -957,6 +957,7 @@ contains
     select case(name)
     case("precip", "rmelt")
        dest(1) = this%model%forcing%precip(1)
+!       dest(1) = this%model%derived%precip_comb
        bmi_status = BMI_SUCCESS
     case("tair")
        dest(1) = this%model%forcing%tair(1)


### PR DESCRIPTION
https://jira.nextgenwaterprediction.com/browse/NGWPC-9882

I need to update the SAC-SMA module to output rain+melt for plotting in ngenCERF.

Incorporating precipitation into calibration plots was originally based on calculations in ngen-cal/cal-mgr derived from forcing data in catchment CSV files. When we switched to the BMI forcing engine, these values were no longer available in the same way, but they could be written from Noah OWP modular (NOM), so we used NOM to write the precipitation. The integration of PET now opens the door to formulations that do not require NOM, so to continue to include precipitation in plots we need another solution. All rainfall runoff models except for SAC-SMA include the ability to write precipitation. This story is to add the capability to SAC-SMA. 

One complication may be that the rainfall input to SAC-SMA may come from the forcing data if there is no snow model present, or it will be a rain+melt input from a snow model. It would be best if this were consistent between rainfall runoff models.  

## Additions

Added Output variable "rmelt" and made sure input "precip" is being passed as "rmelt"

TEST:

https://confluence.nextgenwaterprediction.com/spaces/NGWPC/pages/90177659/RR+models+Consistent+rain+melt+Output#RRmodelsConsistentrain+meltOutput-SAC-SMA

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
