### PR TITLE
Bug Fixes for Serialization (NGWPC-9908)

### DIFF
--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -596,7 +596,7 @@ contains
     integer :: bmi_status
     character(len=BMI_MAX_TYPE_NAME) :: ser_create = "int" !pads spaces upto 2048.
     character(len=BMI_MAX_TYPE_NAME) :: ser_size = "int" !pads spaces upto 2048
-    character(len=BMI_MAX_TYPE_NAME) :: ser_state = "character" !pads spaces upto 2048
+    character(len=BMI_MAX_TYPE_NAME) :: ser_state = "int" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_free = "int" !pads spaces upto 2048
 
     select case(name)

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -953,7 +953,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
          else
-            dest = size(this%model%serialization_buffer)
+            dest = sizeof(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
       case("serialization_state")

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -886,7 +886,7 @@ contains
     double precision :: d
     
     if (name == "serialization_create" .or. name == "serialization_size") then
-      nbytes = storage_size(0_int64)/8 !returns size in bits. So, divide by 8 for bytes.
+      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
       bmi_status = BMI_SUCCESS
     else if (name == "serialization_state") then
       if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -953,7 +953,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
          else
-            dest = sizeof(this%model%serialization_buffer)
+            dest = size(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
       case("serialization_state")

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -764,6 +764,7 @@ contains
     character (len=*), intent(in) :: name
     integer, intent(out) :: size
     integer :: bmi_status
+    double precision :: d
 
     select case(name)
     case("precip")
@@ -864,11 +865,12 @@ contains
     case("hru_area")
        size = sizeof(this%model%parameters%hru_area(1))
        bmi_status = BMI_SUCCESS
-    case("serialization_state")
-       size = 1
+    case("serialization_create", "serialization_size", "serialization_free", "serialization_state")
+       size = sizeof(0_int32)
        bmi_status = BMI_SUCCESS
-    case("serialization_create", "serialization_size", "serialization_free", "reset_time")
-       bmi_status = sac_var_nbytes(this, name, size)
+    case("reset_time")
+       size = sizeof(d)
+       bmi_status = BMI_SUCCESS
     case default
        size = -1
        bmi_status = BMI_FAILURE
@@ -878,37 +880,28 @@ contains
 
   ! The size of the given variable.
   function sac_var_nbytes(this, name, nbytes) result (bmi_status)
-    class (bmi_sac), intent(in) :: this
-    character (len=*), intent(in) :: name
-    integer, intent(out) :: nbytes
-    integer :: bmi_status
-    integer :: s1, s2, s3, grid, grid_size, item_size
-    double precision :: d
-    
-    if (name == "serialization_create" .or. name == "serialization_size") then
-      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
-      bmi_status = BMI_SUCCESS
-    else if (name == "serialization_state") then
-      if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-         if (this%model%serialization_size > 0) then
-            nbytes = this%model%serialization_size
-            bmi_status = BMI_SUCCESS
-         else
-            nbytes = -1
-            call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-            bmi_status = BMI_FAILURE
-         end if
-      else
+   class (bmi_sac), intent(in) :: this
+   character (len=*), intent(in) :: name
+   integer, intent(out) :: nbytes
+   integer :: bmi_status
+   integer :: s1, s2, s3, grid, grid_size, item_size
+   double precision :: d
+   select case(name)
+   case("serialization_create", "serialization_size", "serialization_free", "reset_time")
+      bmi_status = sac_var_itemsize(this, name, nbytes)
+   case("serialization_state")
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
          nbytes = sizeof(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
+      else if (this%model%serialization_buffer > 0) then
+         nbytes = this%model%serialization_size
+         bmi_status = BMI_SUCCESS
+      else
+         call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+         nbytes = 0
+         bmi_status = BMI_FAILURE
       end if
-    else if (name == "serialization_free") then 
-      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
-      bmi_status = BMI_SUCCESS
-    else if (name == "reset_time") then
-      nbytes = storage_size(d) / 8
-      bmi_status = BMI_SUCCESS
-    else
+   case default
       s1 = this%get_var_grid(name, grid)
       s2 = this%get_grid_size(grid, grid_size)
       s3 = this%get_var_itemsize(name, item_size)
@@ -920,7 +913,7 @@ contains
          bmi_status = BMI_FAILURE
          call write_log("nbytes for variable " // name // " not found!", LOG_LEVEL_WARNING)
       end if
-    end if
+   end select
   end function sac_var_nbytes
 
   ! The location (node, face, edge) of the given variable.
@@ -943,6 +936,8 @@ contains
     character (len=*), intent(in) :: name
     integer, intent(inout) :: dest(:)
     integer :: bmi_status, exec_status
+    character(len=20) :: dest_size
+    character(len=20) :: ser_size
     select case(name)
 !     case("model__identification_number")
 !        dest = [this%model%id]
@@ -953,16 +948,25 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
          else
-            dest = size(this%model%serialization_buffer)
+            dest(:) = size(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
       case("serialization_state")
-         if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
+         if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
+            if(size(dest) == size(this%model%serialization_buffer)) then
+               dest(:) = this%model%serialization_buffer(:)
+               bmi_status = BMI_SUCCESS
+            else
+               write(dest_size, "(I20)") size(dest)
+               write(ser_size, "(I20)") size(this%model%serialization_buffer)
+               call write_log("The destination size (" // trim(dest_size) &
+                  // ") does not match the serializations size (" // trim(ser_size) // ")", &
+                  LOG_LEVEL_SEVERE)
+               bmi_status = BMI_FAILURE
+            end if
+         else
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
-         else
-            dest(:) = this%model%serialization_buffer(:)
-            bmi_status = BMI_SUCCESS
          end if
       case default
          dest(:) = -1

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -1231,7 +1231,7 @@ contains
          call reset_model_time(this%model, exec_status)
          if (exec_status == 0) then
             bmi_status = BMI_SUCCESS
-            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_INFO)
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
          else
             bmi_status = BMI_FAILURE
             call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -594,8 +594,8 @@ contains
     character (len=*), intent(in) :: name
     character (len=*), intent(out) :: type
     integer :: bmi_status
-    character(len=BMI_MAX_TYPE_NAME) :: ser_create = "uint64" !pads spaces upto 2048.
-    character(len=BMI_MAX_TYPE_NAME) :: ser_size = "uint64" !pads spaces upto 2048
+    character(len=BMI_MAX_TYPE_NAME) :: ser_create = "int" !pads spaces upto 2048.
+    character(len=BMI_MAX_TYPE_NAME) :: ser_size = "int" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_state = "character" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_free = "int" !pads spaces upto 2048
 
@@ -624,6 +624,9 @@ contains
        bmi_status = BMI_SUCCESS
     case ('serialization_free')
        type = ser_free
+       bmi_status = BMI_SUCCESS
+    case("reset_time")
+       type = "double"
        bmi_status = BMI_SUCCESS
     case default
        type = "-"

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -899,7 +899,7 @@ contains
             bmi_status = BMI_FAILURE
          end if
       else
-         nbytes = size(this%model%serialization_buffer)
+         nbytes = sizeof(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
       end if
     else if (name == "serialization_free") then 
@@ -961,7 +961,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
          else
-            dest = this%model%serialization_buffer
+            dest(:) = this%model%serialization_buffer(:)
             bmi_status = BMI_SUCCESS
          end if
       case default

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -861,6 +861,11 @@ contains
     case("hru_area")
        size = sizeof(this%model%parameters%hru_area(1))
        bmi_status = BMI_SUCCESS
+    case("serialization_state")
+       size = 1
+       bmi_status = BMI_SUCCESS
+    case("serialization_create", "serialization_size", "serialization_free", "reset_time")
+       bmi_status = sac_var_nbytes(this, name, size)
     case default
        size = -1
        bmi_status = BMI_FAILURE
@@ -875,21 +880,30 @@ contains
     integer, intent(out) :: nbytes
     integer :: bmi_status
     integer :: s1, s2, s3, grid, grid_size, item_size
+    double precision :: d
     
     if (name == "serialization_create" .or. name == "serialization_size") then
       nbytes = storage_size(0_int64)/8 !returns size in bits. So, divide by 8 for bytes.
       bmi_status = BMI_SUCCESS
     else if (name == "serialization_state") then
       if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-         nbytes = -1
-         call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-         bmi_status = BMI_FAILURE
+         if (this%model%serialization_size > 0) then
+            nbytes = this%model%serialization_size
+            bmi_status = BMI_SUCCESS
+         else
+            nbytes = -1
+            call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+            bmi_status = BMI_FAILURE
+         end if
       else
-         nbytes = size(this%model%serialization_buffer,KIND=int64)
+         nbytes = size(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
       end if
     else if (name == "serialization_free") then 
       nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
+      bmi_status = BMI_SUCCESS
+    else if (name == "reset_time") then
+      nbytes = storage_size(d) / 8
       bmi_status = BMI_SUCCESS
     else
       s1 = this%get_var_grid(name, grid)
@@ -936,10 +950,17 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
          else
-            dest = size(this%model%serialization_buffer, KIND=int64)
+            dest = size(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
-
+      case("serialization_state")
+         if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
+            call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+            bmi_status = BMI_FAILURE
+         else
+            dest = this%model%serialization_buffer
+            bmi_status = BMI_SUCCESS
+         end if
       case default
          dest(:) = -1
          bmi_status = BMI_FAILURE
@@ -1090,9 +1111,6 @@ contains
  !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR INTEGER VARS =================
 
      select case(name)
-      case("serialization_state")
-        dest_ptr = this%model%serialization_buffer
-        bmi_status = BMI_SUCCESS
       case default
         bmi_status = BMI_FAILURE
         call write_log("Integer pointer value for variable " // name // " not found!", LOG_LEVEL_WARNING)
@@ -1213,6 +1231,7 @@ contains
             bmi_status = BMI_FAILURE
             call write_log(" Failed to create serialized data for state saving", LOG_LEVEL_FATAL)
          end if
+         this%model%serialization_size = -1
       case("serialization_state")
          call deserialize_mp_buffer(this%model, src, exec_status)
          if (exec_status == 0) then
@@ -1222,20 +1241,16 @@ contains
             bmi_status = BMI_FAILURE
             call write_log("Failed to restore serialized data for state saving", LOG_LEVEL_FATAL)
          end if
+         this%model%serialization_size = -1
       case("serialization_free")
          if(allocated(this%model%serialization_buffer)) then
             deallocate(this%model%serialization_buffer)
          end if
          bmi_status = BMI_SUCCESS
-      case("reset_time")
-         call reset_model_time(this%model, exec_status)
-         if (exec_status == 0) then
-            bmi_status = BMI_SUCCESS
-            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
-         else
-            bmi_status = BMI_FAILURE
-            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
-         end if
+         this%model%serialization_size = -1
+      case("serialization_size")
+         this%model%serialization_size = src(1)
+         bmi_status = BMI_SUCCESS
       case default
          bmi_status = BMI_FAILURE
          call write_log(" Failed to set integer value for  " // name // "", LOG_LEVEL_WARNING)
@@ -1359,10 +1374,20 @@ contains
     character (len=*), intent(in) :: name
     double precision, intent(in) :: src(:)
     integer :: bmi_status
+    integer(kind=int64) :: exec_status
 
     !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR DOUBLE VARS =================
 
     select case(name)
+      case("reset_time")
+         call reset_model_time(this%model, exec_status)
+         if (exec_status == 0) then
+            bmi_status = BMI_SUCCESS
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
+         else
+            bmi_status = BMI_FAILURE
+            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
+         end if
     case default
        bmi_status = BMI_FAILURE
     end select

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -893,7 +893,7 @@ contains
       if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
          nbytes = sizeof(this%model%serialization_buffer)
          bmi_status = BMI_SUCCESS
-      else if (this%model%serialization_buffer > 0) then
+      else if (this%model%serialization_size > 0) then
          nbytes = this%model%serialization_size
          bmi_status = BMI_SUCCESS
       else

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -1227,6 +1227,15 @@ contains
             deallocate(this%model%serialization_buffer)
          end if
          bmi_status = BMI_SUCCESS
+      case("reset_time")
+         call reset_model_time(this%model, exec_status)
+         if (exec_status == 0) then
+            bmi_status = BMI_SUCCESS
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_INFO)
+         else
+            bmi_status = BMI_FAILURE
+            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
+         end if
       case default
          bmi_status = BMI_FAILURE
          call write_log(" Failed to set integer value for  " // name // "", LOG_LEVEL_WARNING)

--- a/src/bmi/bmi_sac.f90
+++ b/src/bmi/bmi_sac.f90
@@ -948,7 +948,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
          else
-            dest(:) = size(this%model%serialization_buffer)
+            dest(:) = sizeof(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
       case("serialization_state")

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -353,10 +353,10 @@ contains
           deallocate(model%serialization_buffer)
         end if
         ser_size = size(serialization_buffer)
-        ser_ints = CEILING(real(ser_size) / sizeof(ser_size))
+        ser_ints = CEILING(real(ser_size) / sizeof(0_int32))
         allocate(model%serialization_buffer(ser_ints + 1))
         model%serialization_buffer(1) = ser_size
-        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:), ser_ints)
+        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:))
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -292,6 +292,17 @@ contains
   
   end subroutine cleanup
 
+  SUBROUTINE reset_model_time(model, exec_status)
+    type(sac_type), intent(inout) :: model
+    integer(kind=int64), intent(out) :: exec_status
+    exec_status = 1
+    ! reset time variables to the beginning
+    model%runinfo%itime          = 1                    ! initialize the time loop counter at 1
+    model%runinfo%time_dbl       = 0.d0                 ! start model run at t = 0.0
+    model%runinfo%curr_datetime  = model%runinfo%start_datetime !reset to start time.
+    exec_status = 0
+  END SUBROUTINE reset_model_time
+
   SUBROUTINE new_serialization_request (model, exec_status)
     type(sac_type), intent(inout) :: model
     integer(kind=int64) :: nh !counter for HRUs

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -25,7 +25,7 @@ module runModule
     type(modelvar_type)   :: modelvar
     type(derived_type)    :: derived
     integer               :: serialization_size
-    byte, dimension(:), allocatable :: serialization_buffer
+    integer, dimension(:), allocatable :: serialization_buffer
   end type sac_type
 
 contains
@@ -315,8 +315,7 @@ contains
     class(mp_arr_type), allocatable :: mp_hru_arr
     byte, dimension(:), allocatable :: serialization_buffer
     integer(kind=int64), intent(out) :: exec_status
-    integer :: ser_size
-    byte, dimension(4) :: byte_size
+    integer :: ser_size, ser_ints
 
     mp = msgpack()
     mp_hru_arr = mp_arr_type(model%runinfo%n_hrus)
@@ -350,14 +349,14 @@ contains
     else
         exec_status = 0
         ! add size of serialized data as first four bytes header
-        ser_size = size(serialization_buffer)
-        byte_size = transfer(ser_size, byte_size, size=4)
         if (allocated(model%serialization_buffer)) then
           deallocate(model%serialization_buffer)
         end if
-        allocate(model%serialization_buffer(ser_size + 4))
-        model%serialization_buffer(1:4) = byte_size(1:4)
-        model%serialization_buffer(5:) = serialization_buffer
+        ser_size = size(serialization_buffer)
+        ser_ints = CEILING(real(ser_size) / sizeof(ser_size))
+        allocate(model%serialization_buffer(ser_ints + 1))
+        model%serialization_buffer(1) = ser_size
+        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:), ser_ints)
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request

--- a/src/share/runSac.f90
+++ b/src/share/runSac.f90
@@ -24,6 +24,7 @@ module runModule
     type(forcing_type)    :: forcing
     type(modelvar_type)   :: modelvar
     type(derived_type)    :: derived
+    integer               :: serialization_size
     byte, dimension(:), allocatable :: serialization_buffer
   end type sac_type
 
@@ -46,6 +47,8 @@ contains
               
     call write_log('Initializing Sac-SMA from file', LOG_LEVEL_INFO)
     sac_log_level = get_log_level()
+
+    model%serialization_size = -1
 
     !-----------------------------------------------------------------------------------------
       !  read namelist, initialize data structures and read parameters
@@ -312,6 +315,8 @@ contains
     class(mp_arr_type), allocatable :: mp_hru_arr
     byte, dimension(:), allocatable :: serialization_buffer
     integer(kind=int64), intent(out) :: exec_status
+    integer :: ser_size
+    byte, dimension(4) :: byte_size
 
     mp = msgpack()
     mp_hru_arr = mp_arr_type(model%runinfo%n_hrus)
@@ -344,7 +349,15 @@ contains
         exec_status = 1
     else
         exec_status = 0
-        model%serialization_buffer = serialization_buffer
+        ! add size of serialized data as first four bytes header
+        ser_size = size(serialization_buffer)
+        byte_size = transfer(ser_size, byte_size, size=4)
+        if (allocated(model%serialization_buffer)) then
+          deallocate(model%serialization_buffer)
+        end if
+        allocate(model%serialization_buffer(ser_size + 4))
+        model%serialization_buffer(1:4) = byte_size(1:4)
+        model%serialization_buffer(5:) = serialization_buffer
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request
@@ -366,8 +379,9 @@ contains
 
     mp = msgpack()
     !convert integer(4) to integer(1) for messagepack
-    allocate(serialized_data_1b(size(serialized_data, 1, int64)*4_int64))
-    serialized_data_1b = transfer(serialized_data, serialized_data_1b) 
+    ! true size of byte data is stored in the first four bytes of the byte data
+    allocate( serialized_data_1b( serialized_data(1) ) )
+    serialized_data_1b = transfer(serialized_data(2:), serialized_data_1b, size=serialized_data(1))
     call mp%unpack(serialized_data_1b, mpv)
     if (is_arr(mpv)) then
       call get_arr_ref(mpv, arr_state, status) 


### PR DESCRIPTION
This PR adds support for serialization messaging. Some of these changes are based around the limitations of the Fortran BMI interface that limits the use of raw pointers and restricts value types to `int`, `float`, and `double`.

Accepting this PR will include all changes currently in https://github.com/NGWPC/sac-sma/pull/5

## Additions

- `serialization_size` is a valid input for allowing the `get_value_nbytes` to reflect an incoming size for serialized data. This works around the limitation of passing arbitrarily sized serialization data to the Fortran BMI to read.

## Removals

-

## Changes

- `serialization_size`, `serialization_create`, and `serialization_state` all use `int` as their type for BMI messaging.

## Testing

1. Jeff Wade tested with several NGEN formulations to show saving and loading with no errors.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
